### PR TITLE
Add with_values() function

### DIFF
--- a/src/mask.rs
+++ b/src/mask.rs
@@ -62,7 +62,7 @@ impl<C, A> From<Mask<C, A>> for Rgb<C, A>
         let green = C::MAX;
         let blue = C::MAX;
         let alpha = c.alpha().into();
-        Rgb::with_alpha(red, green, blue, alpha)
+        Rgb::with_values(red, green, blue, alpha)
     }
 }
 


### PR DESCRIPTION
I created a separate `with_values()` function, for the moment it is public, but maybe should be private.  It is the same as the old `with_alpha()` which confusingly allowed opaque alpha.  The new `with_alpha()` forces translucent alpha.  And makes it possible for:

```rust
Rbga8::with_alpha(0, 0, 0, Translucent::new(0));
```

to become 

```rust
Rgba8::with_alpha(0, 0, 0, 0);
```