### PR TITLE
Add Same Implementations On Gray That Were On Rgb

### DIFF
--- a/src/gray.rs
+++ b/src/gray.rs
@@ -29,6 +29,24 @@ impl<C: Channel, A: Alpha> Iterator for Gray<C, A> {
     }
 }
 
+impl<C> From<Gray<C, Translucent<C>>> for Gray<C, Opaque<C>>
+where
+    C: Channel,
+{
+    fn from(c: Gray<C, Translucent<C>>) -> Self {
+        Gray::new(c.value())
+    }
+}
+
+impl<C> From<Gray<C, Opaque<C>>> for Gray<C, Translucent<C>>
+where
+    C: Channel,
+{
+    fn from(c: Gray<C, Opaque<C>>) -> Self {
+        Gray::with_alpha(c.value(), C::MAX)
+    }
+}
+
 impl<C, A> From<u8> for Gray<C, A>
 where
     C: Channel,
@@ -54,13 +72,13 @@ impl<C: Channel, A: Alpha> Gray<C, A> {
         Gray { value, alpha }
     }
     /// Create a [Translucent](struct.Translucent.html) gray value.
-    pub fn with_alpha<H>(value: H, alpha: H) -> Self
+    pub fn with_alpha<H, B>(value: H, alpha: B) -> Self
     where
         C: From<H>,
-        A: From<C>,
+        A: From<B>,
     {
         let value = C::from(value);
-        let alpha = A::from(C::from(alpha));
+        let alpha = A::from(alpha);
         Gray { value, alpha }
     }
     /// Get the gray value.

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2019  Douglas P Lau
 //
 use crate::{
-    Alpha, Ch16, Ch32, Ch8, Channel, Format, PixModes, Rgb, Translucent,
+    Alpha, Ch16, Ch32, Ch8, Channel, Format, PixModes, Rgb, Gray, Translucent,
 };
 use std::marker::PhantomData;
 
@@ -62,7 +62,6 @@ where
 impl<C, A> From<Mask<C, A>> for Rgb<C, A>
 where
     C: Channel,
-    Ch8: From<C>,
     A: Alpha<Chan = C>,
 {
     /// Get an `Rgb` from a `Mask`
@@ -72,6 +71,19 @@ where
         let blue = C::MAX;
         let alpha = c.alpha().into();
         Rgb::with_alpha(red, green, blue, alpha)
+    }
+}
+
+impl<C, A> From<Mask<C, A>> for Gray<C, A>
+where
+    C: Channel,
+    A: Alpha<Chan = C>,
+{
+    /// Get a `Gray` from a `Mask`
+    fn from(c: Mask<C, A>) -> Self {
+        let value = C::MAX;
+        let alpha = c.alpha().into();
+        Gray::with_alpha(value, alpha)
     }
 }
 


### PR DESCRIPTION
This also adds the following convenience implementations, as to not break the tests using `GrayAlpha8`:
```
impl From<u8> for Translucent<Ch8>
impl From<u16> for Translucent<Ch16>
impl From<f32> for Translucent<Ch32>
```

Additionally, converting to `Mask` from an `Rgb` no longer requires `Channel` to be a `Ch8`.  `Gray` is implemented the same way.