### PR TITLE
Renaming Type Aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * GammaModeID can now be UnknownGamma (for masks)
 * Implemented Add for Ch8, Ch16, and Ch32
 * Type aliases for new generics
+* Format::convert method
 ### Changed
 * Gamma and Alpha are now Generics on Gray, Rgb instead of attributes on Raster
 * Rename AlphaMode to AlphaModeID

--- a/examples/checker.rs
+++ b/examples/checker.rs
@@ -1,6 +1,6 @@
 extern crate pix;
 
-use pix::{SepSGray8, Raster, RasterBuilder};
+use pix::{Raster, RasterBuilder, SepSGray8};
 use std::fs::File;
 use std::io;
 use std::io::Write;

--- a/examples/checker.rs
+++ b/examples/checker.rs
@@ -1,13 +1,13 @@
 extern crate pix;
 
-use pix::{Gray8, Raster, RasterBuilder};
+use pix::{SepSGray8, Raster, RasterBuilder};
 use std::fs::File;
 use std::io;
 use std::io::Write;
 
 fn main() -> Result<(), io::Error> {
-    let v = Gray8::from(255);
-    let mut r = RasterBuilder::<Gray8>::new().with_clear(16, 16);
+    let v = SepSGray8::from(255);
+    let mut r = RasterBuilder::<SepSGray8>::new().with_clear(16, 16);
     for y in 0..16 {
         for x in 0..16 {
             if x + y & 1 != 0 {
@@ -18,7 +18,7 @@ fn main() -> Result<(), io::Error> {
     write_pgm(&r, "checker.pgm")
 }
 
-fn write_pgm(raster: &Raster<Gray8>, filename: &str) -> io::Result<()> {
+fn write_pgm(raster: &Raster<SepSGray8>, filename: &str) -> io::Result<()> {
     let fl = File::create(filename)?;
     let mut bw = io::BufWriter::new(fl);
     let w = bw.get_mut();

--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -1,6 +1,7 @@
 // alpha.rs     Alpha channel handling.
 //
 // Copyright (c) 2019  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 use crate::{Ch16, Ch32, Ch8, Channel};
 use std::fmt::Debug;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,7 @@
 // channel.rs       Color channels
 //
 // Copyright (c) 2019  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 use crate::gamma::Gamma;
 use std::cmp::Ordering;

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,8 +1,11 @@
 // format.rs     Pixel format.
 //
 // Copyright (c) 2018-2019  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
-use crate::{AlphaMode, Channel, GammaMode, Translucent, AlphaModeID, GammaModeID};
+use crate::{
+    AlphaMode, AlphaModeID, Channel, GammaMode, GammaModeID, Translucent,
+};
 
 /// Pixel format determines [Channel](trait.Channel.html)s and bit depth.
 ///

--- a/src/format.rs
+++ b/src/format.rs
@@ -7,17 +7,72 @@ use crate::{
     AlphaMode, AlphaModeID, Channel, GammaMode, GammaModeID, Translucent,
 };
 
-/// Pixel format determines [Channel](trait.Channel.html)s and bit depth.
+/// Pixel format determines bit depth ([Channel](trait.Channel.html)),
+/// color components, alpha mode, and gamma mode.
+///
+/// The naming scheme for type aliases goes:
+///
+/// * `Sep`/`Assoc` for [separated](struct.SeparatedAlpha.html) and
+///   [associated](struct.AssociatedAlpha.html) alpha.
+/// * `L`/`S` for [linear gamma colorspace](struct.LinearGamma.html) and
+///   [sRGB gamma colorspace](struct.SrgbGamma.html).
+/// * `Gray`/`Mask`/`Rgb` for [Gray](struct.Gray.html),
+///   [Mask](struct.Mask.html), and [Rgb](struct.Rgb.html).
+/// * `8`/`16`/`32` for 8-bit integer, 16-bit integer, and 32-bit floating-point
+///   pixel formats.
+///
+/// The following types are defined:
 ///
 /// * [Gray](struct.Gray.html): [Gray8](type.Gray8.html),
 ///   [Gray16](type.Gray16.html), [Gray32](type.Gray32.html),
 ///   [GrayAlpha8](type.GrayAlpha8.html), [GrayAlpha16](type.GrayAlpha16.html),
 ///   [GrayAlpha32](type.GrayAlpha32.html)
+/// * [SGray](type.SGray.html)
+/// * [SepSGray](type.SepSGray.html): [SepSGray8](type.SepSGray8.html),
+///   [SepSGray16](type.SepSGray16.html), [SepSGray32](type.SepSGray32.html),
+///   [SepSGrayAlpha8](type.SepSGrayAlpha8.html),
+///   [SepSGrayAlpha16](type.SepSGrayAlpha16.html),
+///   [SepSGrayAlpha32](type.SepSGrayAlpha32.html)
+/// * [AssocSGray](type.AssocSGray.html):
+///   [AssocSGrayAlpha8](type.AssocSGrayAlpha8.html),
+///   [AssocSGrayAlpha16](type.AssocSGrayAlpha16.html),
+///   [AssocSGrayAlpha32](type.AssocSGrayAlpha32.html)
+/// * [LGray](type.LGray.html)
+/// * [SepLGray](type.SepLGray.html): [SepLGray8](type.SepLGray8.html),
+///   [SepLGray16](type.SepLGray16.html), [SepLGray32](type.SepLGray32.html),
+///   [SepLGrayAlpha8](type.SepLGrayAlpha8.html),
+///   [SepLGrayAlpha16](type.SepLGrayAlpha16.html),
+///   [SepLGrayAlpha32](type.SepLGrayAlpha32.html)
+/// * [AssocLGray](type.AssocLGray.html):
+///   [AssocLGrayAlpha8](type.AssocLGrayAlpha8.html),
+///   [AssocLGrayAlpha16](type.AssocLGrayAlpha16.html),
+///   [AssocLGrayAlpha32](type.AssocLGrayAlpha32.html)
 /// * [Mask](struct.Mask.html): [Mask8](type.Mask8.html),
 ///   [Mask16](type.Mask16.html), [Mask32](type.Mask32.html)
-/// * [Rgb](struct.Rgb.html): [Rgb8](type.Rgb8.html), [Rgb16](type.Rgb16.html),
-///   [Rgb32](type.Rgb32.html), [Rgba8](type.Rgba8.html),
-///   [Rgba16](type.Rgba16.html), [Rgba32](type.Rgba32.html)
+/// * [Rgb](struct.Rgb.html): [Rgb8](type.Rgb8.html),
+///   [Rgb16](type.Rgb16.html), [Rgb32](type.Rgb32.html),
+///   [Rgba8](type.Rgba8.html), [Rgba16](type.Rgba16.html),
+///   [Rgba32](type.Rgba32.html)
+/// * [SRgb](type.SRgb.html)
+/// * [SepSRgb](type.SepSRgb.html): [SepSRgb8](type.SepSRgb8.html),
+///   [SepSRgb16](type.SepSRgb16.html), [SepSRgb32](type.SepSRgb32.html),
+///   [SepSRgba8](type.SepSRgba8.html),
+///   [SepSRgba16](type.SepSRgba16.html),
+///   [SepSRgba32](type.SepSRgba32.html)
+/// * [AssocSRgb](type.AssocSRgb.html):
+///   [AssocSRgba8](type.AssocSRgba8.html),
+///   [AssocSRgba16](type.AssocSRgba16.html),
+///   [AssocSRgba32](type.AssocSRgba32.html)
+/// * [LRgb](type.LRgb.html)
+/// * [SepLRgb](type.SepLRgb.html): [SepLRgb8](type.SepLRgb8.html),
+///   [SepLRgb16](type.SepLRgb16.html), [SepLRgb32](type.SepLRgb32.html),
+///   [SepLRgba8](type.SepLRgba8.html),
+///   [SepLRgba16](type.SepLRgba16.html),
+///   [SepLRgba32](type.SepLRgba32.html)
+/// * [AssocLRgb](type.AssocLRgb.html):
+///   [AssocLRgba8](type.AssocLRgba8.html),
+///   [AssocLRgba16](type.AssocLRgba16.html),
+///   [AssocLRgba32](type.AssocLRgba32.html)
 ///
 pub trait Format:
     Clone + Copy + Default + PartialEq + AlphaMode + GammaMode

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -1,6 +1,7 @@
 // gamma.rs     Gamma encoding/decoding for sRGB
 //
 // Copyright (c) 2019  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 use crate::{Ch16, Ch32, Ch8, Channel};
 use std::fmt::Debug;

--- a/src/gray.rs
+++ b/src/gray.rs
@@ -1,6 +1,7 @@
 // gray.rs      Grayscale pixel format.
 //
 // Copyright (c) 2018-2020  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 use crate::{
     Alpha, AlphaMode, AlphaModeID, AssociatedAlpha, Ch16, Ch32, Ch8, Channel,

--- a/src/gray.rs
+++ b/src/gray.rs
@@ -196,84 +196,146 @@ where
 
 /// [Opaque](struct.Opaque.html) 8-bit [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type Gray8 = Gray<Ch8, Opaque<Ch8>, SeparatedAlpha, SrgbGamma>;
-
+pub type Gray8<M, G> = Gray<Ch8, Opaque<Ch8>, M, G>;
 /// [Opaque](struct.Opaque.html) 16-bit [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type Gray16 = Gray<Ch16, Opaque<Ch16>, SeparatedAlpha, SrgbGamma>;
-
+pub type Gray16<M, G> = Gray<Ch16, Opaque<Ch16>, M, G>;
 /// [Opaque](struct.Opaque.html) 32-bit [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type Gray32 = Gray<Ch32, Opaque<Ch32>, SeparatedAlpha, SrgbGamma>;
-
-/// [Opaque](struct.Opaque.html) 8-bit [Gray](struct.Gray.html) pixel
-/// [Format](trait.Format.html).
-pub type LinearGray8 = Gray<Ch8, Opaque<Ch8>, SeparatedAlpha, LinearGamma>;
-
-/// [Opaque](struct.Opaque.html) 16-bit [Gray](struct.Gray.html) pixel
-/// [Format](trait.Format.html).
-pub type LinearGray16 = Gray<Ch16, Opaque<Ch16>, SeparatedAlpha, LinearGamma>;
-
-/// [Opaque](struct.Opaque.html) 32-bit [Gray](struct.Gray.html) pixel
-/// [Format](trait.Format.html).
-pub type LinearGray32 = Gray<Ch32, Opaque<Ch32>, SeparatedAlpha, LinearGamma>;
-
+pub type Gray32<M, G> = Gray<Ch32, Opaque<Ch32>, M, G>;
 /// [Translucent](struct.Translucent.html) 8-bit [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type GrayAlpha8 = Gray<Ch8, Translucent<Ch8>, SeparatedAlpha, SrgbGamma>;
-
+pub type GrayAlpha8<M, G> = Gray<Ch8, Translucent<Ch8>, M, G>;
 /// [Translucent](struct.Translucent.html) 16-bit [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type GrayAlpha16 = Gray<Ch16, Translucent<Ch16>, SeparatedAlpha, SrgbGamma>;
-
+pub type GrayAlpha16<M, G> = Gray<Ch16, Translucent<Ch16>, M, G>;
 /// [Translucent](struct.Translucent.html) 32-bit [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type GrayAlpha32 = Gray<Ch32, Translucent<Ch32>, SeparatedAlpha, SrgbGamma>;
+pub type GrayAlpha32<M, G> = Gray<Ch32, Translucent<Ch32>, M, G>;
 
-/// [Translucent](struct.Translucent.html) 8-bit [Gray](struct.Gray.html) pixel
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type LinearGrayAlpha8 =
-    Gray<Ch8, Translucent<Ch8>, SeparatedAlpha, LinearGamma>;
+pub type SGray<C, A, M> = Gray<C, A, M, SrgbGamma>;
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type LGray<C, A, M> = Gray<C, A, M, LinearGamma>;
 
-/// [Translucent](struct.Translucent.html) 16-bit [Gray](struct.Gray.html) pixel
+/// [SeparatedAlpha](struct.SeparatedAlpha.html) [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type LinearGrayAlpha16 =
-    Gray<Ch16, Translucent<Ch16>, SeparatedAlpha, LinearGamma>;
+pub type SepGray<C, A, M> = Gray<C, A, M, SeparatedAlpha>;
+/// [AssociatedAlpha](struct.AssociatedAlpha.html) [Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocGray<C, A, M> = Gray<C, A, M, AssociatedAlpha>;
 
-/// [Translucent](struct.Translucent.html) 32-bit [Gray](struct.Gray.html) pixel
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type LinearGrayAlpha32 =
-    Gray<Ch32, Translucent<Ch32>, SeparatedAlpha, LinearGamma>;
+pub type SepSGray<C, A> = SGray<C, A, SeparatedAlpha>;
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGray<C, A> = LGray<C, A, SeparatedAlpha>;
+/// [AssociatedAlpha](struct.AssociatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocSGray<C, A> = SGray<C, A, AssociatedAlpha>;
+/// [AssociatedAlpha](struct.AssociatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocLGray<C, A> = LGray<C, A, AssociatedAlpha>;
 
-/// [Translucent](struct.Translucent.html) 8-bit [Gray](struct.Gray.html) pixel
+/// [Opaque](struct.Opaque.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulGrayAlpha8 =
-    Gray<Ch8, Translucent<Ch8>, AssociatedAlpha, SrgbGamma>;
+pub type SepSGray8 = SepSGray<Ch8, Opaque<Ch8>>;
+/// [Opaque](struct.Opaque.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSGray16 = SepSGray<Ch16, Opaque<Ch16>>;
+/// [Opaque](struct.Opaque.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSGray32 = SepSGray<Ch32, Opaque<Ch32>>;
+/// [Opaque](struct.Opaque.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGray8 = SepLGray<Ch8, Opaque<Ch8>>;
+/// [Opaque](struct.Opaque.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGray16 = SepLGray<Ch16, Opaque<Ch16>>;
+/// [Opaque](struct.Opaque.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGray32 = SepLGray<Ch32, Opaque<Ch32>>;
 
-/// [Translucent](struct.Translucent.html) 16-bit [Gray](struct.Gray.html) pixel
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulGrayAlpha16 =
-    Gray<Ch16, Translucent<Ch16>, AssociatedAlpha, SrgbGamma>;
+pub type SepSGrayAlpha8 = SepSGray<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSGrayAlpha16 = SepSGray<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSGrayAlpha32 = SepSGray<Ch32, Translucent<Ch32>>;
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGrayAlpha8 = SepLGray<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGrayAlpha16 = SepLGray<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLGrayAlpha32 = SepLGray<Ch32, Translucent<Ch32>>;
 
-/// [Translucent](struct.Translucent.html) 32-bit [Gray](struct.Gray.html) pixel
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulGrayAlpha32 =
-    Gray<Ch32, Translucent<Ch32>, AssociatedAlpha, SrgbGamma>;
-
-/// [Translucent](struct.Translucent.html) 8-bit [Gray](struct.Gray.html) pixel
+pub type AssocSGrayAlpha8 = AssocSGray<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulLinearGrayAlpha8 =
-    Gray<Ch8, Translucent<Ch8>, AssociatedAlpha, LinearGamma>;
-
-/// [Translucent](struct.Translucent.html) 16-bit [Gray](struct.Gray.html) pixel
+pub type AssocSGrayAlpha16 = AssocSGray<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulLinearGrayAlpha16 =
-    Gray<Ch16, Translucent<Ch16>, AssociatedAlpha, LinearGamma>;
-
-/// [Translucent](struct.Translucent.html) 32-bit [Gray](struct.Gray.html) pixel
+pub type AssocSGrayAlpha32 = AssocSGray<Ch32, Translucent<Ch32>>;
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulLinearGrayAlpha32 =
-    Gray<Ch32, Translucent<Ch32>, AssociatedAlpha, LinearGamma>;
+pub type AssocLGrayAlpha8 = AssocLGray<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocLGrayAlpha16 = AssocLGray<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Gray](struct.Gray.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocLGrayAlpha32 = AssocLGray<Ch32, Translucent<Ch32>>;
 
 #[cfg(test)]
 mod test {
@@ -281,11 +343,11 @@ mod test {
 
     #[test]
     fn check_sizes() {
-        assert_eq!(std::mem::size_of::<Gray8>(), 1);
-        assert_eq!(std::mem::size_of::<Gray16>(), 2);
-        assert_eq!(std::mem::size_of::<Gray32>(), 4);
-        assert_eq!(std::mem::size_of::<GrayAlpha8>(), 2);
-        assert_eq!(std::mem::size_of::<GrayAlpha16>(), 4);
-        assert_eq!(std::mem::size_of::<GrayAlpha32>(), 8);
+        assert_eq!(std::mem::size_of::<SepSGray8>(), 1);
+        assert_eq!(std::mem::size_of::<SepSGray16>(), 2);
+        assert_eq!(std::mem::size_of::<SepSGray32>(), 4);
+        assert_eq!(std::mem::size_of::<SepSGrayAlpha8>(), 2);
+        assert_eq!(std::mem::size_of::<SepSGrayAlpha16>(), 4);
+        assert_eq!(std::mem::size_of::<SepSGrayAlpha32>(), 8);
     }
 }

--- a/src/gray.rs
+++ b/src/gray.rs
@@ -85,6 +85,32 @@ where
     }
 }
 
+impl<C, A, G: GammaMode> From<Gray<C, A, SeparatedAlpha, G>>
+    for Gray<C, A, AssociatedAlpha, G>
+where
+    C: Channel,
+    A: Alpha<Chan = C>,
+{
+    fn from(c: Gray<C, A, SeparatedAlpha, G>) -> Self {
+        let value = AssociatedAlpha::encode::<C, A>(c.value, c.alpha);
+
+        Gray::with_alpha(value, c.alpha())
+    }
+}
+
+impl<C, A, G: GammaMode> From<Gray<C, A, AssociatedAlpha, G>>
+    for Gray<C, A, SeparatedAlpha, G>
+where
+    C: Channel,
+    A: Alpha<Chan = C>,
+{
+    fn from(c: Gray<C, A, AssociatedAlpha, G>) -> Self {
+        let value = AssociatedAlpha::decode::<C, A>(c.value, c.alpha);
+
+        Gray::with_alpha(value, c.alpha)
+    }
+}
+
 impl<C, A, M: AlphaMode, G: GammaMode> From<u8> for Gray<C, A, M, G>
 where
     C: Channel,
@@ -222,10 +248,10 @@ pub type LGray<C, A, M> = Gray<C, A, M, LinearGamma>;
 
 /// [SeparatedAlpha](struct.SeparatedAlpha.html) [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type SepGray<C, A, M> = Gray<C, A, M, SeparatedAlpha>;
+pub type SepGray<C, A, G> = Gray<C, A, SeparatedAlpha, G>;
 /// [AssociatedAlpha](struct.AssociatedAlpha.html) [Gray](struct.Gray.html) pixel
 /// [Format](trait.Format.html).
-pub type AssocGray<C, A, M> = Gray<C, A, M, AssociatedAlpha>;
+pub type AssocGray<C, A, G> = Gray<C, A, AssociatedAlpha, G>;
 
 /// [SeparatedAlpha](struct.SeparatedAlpha.html)
 /// [S](struct.SrgbGamma.html)[Gray](struct.Gray.html) pixel

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // lib.rs      Pix crate.
 //
 // Copyright (c) 2019  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 //! Pixel and [Raster](struct.Raster.html) image crate.
 //!
@@ -27,45 +28,21 @@ pub use crate::gamma::{
     GammaMode, GammaModeID, LinearGamma, PowerLawGamma, SrgbGamma,
 };
 pub use crate::gray::{
-    SepLGray16, SepLGray32, SepLGray8, SepLGrayAlpha16, SepLGrayAlpha32,
-    SepLGrayAlpha8, AssocLGrayAlpha16, AssocLGrayAlpha32, AssocLGrayAlpha8,
-    AssocSGrayAlpha16, AssocSGrayAlpha32, AssocSGrayAlpha8, Gray, SepSGray16, SepSGray32, SepSGray8, SepSGrayAlpha16,
-    SepSGrayAlpha32, SepSGrayAlpha8,
-
-    Gray8, Gray16, Gray32,
-    GrayAlpha8, GrayAlpha16, GrayAlpha32,
-
-    SepSGray,
-    SepLGray,
-    AssocSGray,
-    AssocLGray,
-
-    SepGray,
-    AssocGray,
-
-    SGray,
-    LGray,
+    AssocGray, AssocLGray, AssocLGrayAlpha16, AssocLGrayAlpha32,
+    AssocLGrayAlpha8, AssocSGray, AssocSGrayAlpha16, AssocSGrayAlpha32,
+    AssocSGrayAlpha8, Gray, Gray16, Gray32, Gray8, GrayAlpha16, GrayAlpha32,
+    GrayAlpha8, LGray, SGray, SepGray, SepLGray, SepLGray16, SepLGray32,
+    SepLGray8, SepLGrayAlpha16, SepLGrayAlpha32, SepLGrayAlpha8, SepSGray,
+    SepSGray16, SepSGray32, SepSGray8, SepSGrayAlpha16, SepSGrayAlpha32,
+    SepSGrayAlpha8,
 };
 pub use crate::mask::{Mask, Mask16, Mask32, Mask8};
 pub use crate::palette::Palette;
 pub use crate::raster::{Raster, RasterBuilder, RasterIter, Region};
 pub use crate::rgb::{
-    SepLRgb16, SepLRgb32, SepLRgb8, SepLRgba16, SepLRgba32,
-    SepLRgba8, AssocLRgba16, AssocLRgba32, AssocLRgba8,
-    AssocSRgba16, AssocSRgba32, AssocSRgba8, Rgb, SepSRgb16, SepSRgb32, SepSRgb8, SepSRgba16,
-    SepSRgba32, SepSRgba8,
-
-    Rgb8, Rgb16, Rgb32,
-    Rgba8, Rgba16, Rgba32,
-
-    SepSRgb,
-    SepLRgb,
-    AssocSRgb,
-    AssocLRgb,
-
-    SepRgb,
-    AssocRgb,
-
-    SRgb,
-    LRgb,
+    AssocLRgb, AssocLRgba16, AssocLRgba32, AssocLRgba8, AssocRgb, AssocSRgb,
+    AssocSRgba16, AssocSRgba32, AssocSRgba8, LRgb, Rgb, Rgb16, Rgb32, Rgb8,
+    Rgba16, Rgba32, Rgba8, SRgb, SepLRgb, SepLRgb16, SepLRgb32, SepLRgb8,
+    SepLRgba16, SepLRgba32, SepLRgba8, SepRgb, SepSRgb, SepSRgb16, SepSRgb32,
+    SepSRgb8, SepSRgba16, SepSRgba32, SepSRgba8,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,18 +27,45 @@ pub use crate::gamma::{
     GammaMode, GammaModeID, LinearGamma, PowerLawGamma, SrgbGamma,
 };
 pub use crate::gray::{
-    Gray, Gray16, Gray32, Gray8, GrayAlpha16, GrayAlpha32, GrayAlpha8,
-    LinearGray16, LinearGray32, LinearGray8, LinearGrayAlpha16,
-    LinearGrayAlpha32, LinearGrayAlpha8, PremulGrayAlpha16, PremulGrayAlpha32,
-    PremulGrayAlpha8, PremulLinearGrayAlpha16, PremulLinearGrayAlpha32,
-    PremulLinearGrayAlpha8,
+    SepLGray16, SepLGray32, SepLGray8, SepLGrayAlpha16, SepLGrayAlpha32,
+    SepLGrayAlpha8, AssocLGrayAlpha16, AssocLGrayAlpha32, AssocLGrayAlpha8,
+    AssocSGrayAlpha16, AssocSGrayAlpha32, AssocSGrayAlpha8, Gray, SepSGray16, SepSGray32, SepSGray8, SepSGrayAlpha16,
+    SepSGrayAlpha32, SepSGrayAlpha8,
+
+    Gray8, Gray16, Gray32,
+    GrayAlpha8, GrayAlpha16, GrayAlpha32,
+
+    SepSGray,
+    SepLGray,
+    AssocSGray,
+    AssocLGray,
+
+    SepGray,
+    AssocGray,
+
+    SGray,
+    LGray,
 };
 pub use crate::mask::{Mask, Mask16, Mask32, Mask8};
 pub use crate::palette::Palette;
 pub use crate::raster::{Raster, RasterBuilder, RasterIter, Region};
 pub use crate::rgb::{
-    LinearRgb16, LinearRgb32, LinearRgb8, LinearRgba16, LinearRgba32,
-    LinearRgba8, PremulLinearRgba16, PremulLinearRgba32, PremulLinearRgba8,
-    PremulRgba16, PremulRgba32, PremulRgba8, Rgb, Rgb16, Rgb32, Rgb8, Rgba16,
-    Rgba32, Rgba8,
+    SepLRgb16, SepLRgb32, SepLRgb8, SepLRgba16, SepLRgba32,
+    SepLRgba8, AssocLRgba16, AssocLRgba32, AssocLRgba8,
+    AssocSRgba16, AssocSRgba32, AssocSRgba8, Rgb, SepSRgb16, SepSRgb32, SepSRgb8, SepSRgba16,
+    SepSRgba32, SepSRgba8,
+
+    Rgb8, Rgb16, Rgb32,
+    Rgba8, Rgba16, Rgba32,
+
+    SepSRgb,
+    SepLRgb,
+    AssocSRgb,
+    AssocLRgb,
+
+    SepRgb,
+    AssocRgb,
+
+    SRgb,
+    LRgb,
 };

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -1,6 +1,7 @@
 // mask.rs      Alpha mask pixel format.
 //
 // Copyright (c) 2019-2020  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 use crate::{
     Alpha, AlphaMode, AlphaModeID, AssociatedAlpha, Ch16, Ch32, Ch8, Channel,

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -150,17 +150,17 @@ mod test {
         assert_eq!(p.entry(4), None);
         // test insertion
         for i in 0..16 {
-            let idx = p.set_entry(Rgb8::new(i, i, i)).unwrap();
+            let idx = p.set_entry(SepSRgb8::new(i, i, i)).unwrap();
             assert_eq!(i as usize, idx);
         }
-        assert_eq!(p.set_entry(Rgb8::new(255, 255, 255)), None);
+        assert_eq!(p.set_entry(SepSRgb8::new(255, 255, 255)), None);
         // test lookup
         for i in 0..16 {
-            let idx = p.set_entry(Rgb8::new(i, i, i)).unwrap();
+            let idx = p.set_entry(SepSRgb8::new(i, i, i)).unwrap();
             assert_eq!(i as usize, idx);
         }
-        assert_eq!(p.entry(5), Some(Rgb8::new(5, 5, 5)));
-        p.replace_entry(5, Rgb8::new(0x55, 0x55, 0x55));
+        assert_eq!(p.entry(5), Some(SepSRgb8::new(5, 5, 5)));
+        p.replace_entry(5, SepSRgb8::new(0x55, 0x55, 0x55));
         let v = vec![
             0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x02, 0x02, 0x02, 0x03, 0x03,
             0x03, 0x04, 0x04, 0x04, 0x55, 0x55, 0x55, 0x06, 0x06, 0x06, 0x07,
@@ -174,7 +174,7 @@ mod test {
     fn check_hist() {
         let mut p = Palette::new(8);
         for i in 0..7 {
-            p.set_entry(Rgb8::new(i, i, i));
+            p.set_entry(SepSRgb8::new(i, i, i));
         }
         let v: Vec<u8> = vec![
             0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x01, 0x02, 0x04, 0x01,
@@ -188,13 +188,13 @@ mod test {
     #[test]
     fn matching() {
         let mut p = Palette::new(8);
-        assert_eq!(p.set_entry(Rgb8::new(10, 10, 10)), Some(0));
-        assert_eq!(p.set_entry(Rgb8::new(20, 20, 20)), Some(1));
-        assert_eq!(p.set_entry(Rgb8::new(30, 30, 30)), Some(2));
-        assert_eq!(p.set_entry(Rgb8::new(40, 40, 40)), Some(3));
-        p.set_threshold_fn(|_| Rgb8::new(4, 5, 6));
-        assert_eq!(p.set_entry(Rgb8::new(15, 15, 15)), Some(4));
-        p.set_threshold_fn(|_| Rgb8::new(5, 5, 5));
-        assert_eq!(p.set_entry(Rgb8::new(35, 35, 35)), Some(2));
+        assert_eq!(p.set_entry(SepSRgb8::new(10, 10, 10)), Some(0));
+        assert_eq!(p.set_entry(SepSRgb8::new(20, 20, 20)), Some(1));
+        assert_eq!(p.set_entry(SepSRgb8::new(30, 30, 30)), Some(2));
+        assert_eq!(p.set_entry(SepSRgb8::new(40, 40, 40)), Some(3));
+        p.set_threshold_fn(|_| SepSRgb8::new(4, 5, 6));
+        assert_eq!(p.set_entry(SepSRgb8::new(15, 15, 15)), Some(4));
+        p.set_threshold_fn(|_| SepSRgb8::new(5, 5, 5));
+        assert_eq!(p.set_entry(SepSRgb8::new(35, 35, 35)), Some(2));
     }
 }

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -1,8 +1,9 @@
 // raster.rs    Raster images.
 //
 // Copyright (c) 2017-2020  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
-use crate::{ Ch16, Ch8, Channel, Format, };
+use crate::{Ch16, Ch8, Channel, Format};
 use std::convert::TryFrom;
 use std::marker::PhantomData;
 

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 /// ### Create a `Raster`
 /// ```
 /// # use pix::*;
-/// let r = RasterBuilder::<Rgb8>::new().with_clear(100, 100);
+/// let r = RasterBuilder::<SepSRgb8>::new().with_clear(100, 100);
 /// ```
 pub struct RasterBuilder<F: Format> {
     _format: PhantomData<F>,
@@ -35,8 +35,8 @@ pub struct RasterBuilder<F: Format> {
 /// ### Create a `Raster` with a solid color rectangle
 /// ```
 /// # use pix::*;
-/// let mut raster = RasterBuilder::<Rgb8>::new().with_clear(10, 10);
-/// raster.set_region((2, 4, 3, 3), Rgb8::new(0xFF, 0xFF, 0x00));
+/// let mut raster = RasterBuilder::<SepSRgb8>::new().with_clear(10, 10);
+/// raster.set_region((2, 4, 3, 3), SepSRgb8::new(0xFF, 0xFF, 0x00));
 /// ```
 pub struct Raster<F: Format> {
     width: u32,
@@ -60,7 +60,7 @@ pub struct Raster<F: Format> {
 /// ### `Iterator` of `Region` within a `Raster`
 /// ```
 /// # use pix::*;
-/// let mut gray = RasterBuilder::<GrayAlpha16>::new().with_clear(40, 40);
+/// let mut gray = RasterBuilder::<SepSGrayAlpha16>::new().with_clear(40, 40);
 /// // ... load raster data
 /// let region = gray.region().intersection((20, 20, 10, 10));
 /// let it = gray.region_iter(region);
@@ -85,7 +85,7 @@ pub struct RasterIter<'a, F: Format> {
 /// ### Create from Raster
 /// ```
 /// # use pix::*;
-/// let r = RasterBuilder::<Rgb8>::new().with_clear(100, 100);
+/// let r = RasterBuilder::<SepSRgb8>::new().with_clear(100, 100);
 /// let reg = r.region(); // (0, 0, 100, 100)
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -129,10 +129,10 @@ impl<F: Format> RasterBuilder<F> {
     /// ## Examples
     /// ```
     /// # use pix::*;
-    /// let r1 = RasterBuilder::<Gray8>::new().with_clear(20, 20);
+    /// let r1 = RasterBuilder::<SepSGray8>::new().with_clear(20, 20);
     /// let r2 = RasterBuilder::<Mask8>::new().with_clear(64, 64);
-    /// let r3 = RasterBuilder::<Rgb16>::new().with_clear(10, 10);
-    /// let r4 = RasterBuilder::<GrayAlpha32>::new().with_clear(100, 250);
+    /// let r3 = RasterBuilder::<SepSRgb16>::new().with_clear(10, 10);
+    /// let r4 = RasterBuilder::<SepSGrayAlpha32>::new().with_clear(100, 250);
     /// ```
     pub fn with_clear(self, width: u32, height: u32) -> Raster<F> {
         self.with_color(width, height, F::default())
@@ -142,8 +142,8 @@ impl<F: Format> RasterBuilder<F> {
     /// ## Example
     /// ```
     /// # use pix::*;
-    /// let clr = Rgb8::new(0x40, 0xAA, 0xBB);
-    /// let r = RasterBuilder::<Rgb8>::new().with_clear(15, 15);
+    /// let clr = SepSRgb8::new(0x40, 0xAA, 0xBB);
+    /// let r = RasterBuilder::<SepSRgb8>::new().with_clear(15, 15);
     /// ```
     pub fn with_color(self, width: u32, height: u32, clr: F) -> Raster<F> {
         let len = (width * height) as usize;
@@ -163,9 +163,9 @@ impl<F: Format> RasterBuilder<F> {
     /// ### Convert from Rgb8 to Rgba16
     /// ```
     /// # use pix::*;
-    /// let mut r0 = RasterBuilder::<Rgb8>::new().with_clear(50, 50);
+    /// let mut r0 = RasterBuilder::<SepSRgb8>::new().with_clear(50, 50);
     /// // load pixels into raster
-    /// let r1 = RasterBuilder::<Rgba16>::new().with_raster(&r0);
+    /// let r1 = RasterBuilder::<SepSRgba16>::new().with_raster(&r0);
     /// ```
     pub fn with_raster<C, H, P>(self, o: &Raster<P>) -> Raster<F>
     where
@@ -195,12 +195,12 @@ impl<F: Format> RasterBuilder<F> {
     /// ## Example
     /// ```
     /// # use pix::*;
-    /// let p = vec![Rgb8::new(255, 0, 255); 16]; // vec of magenta pix
+    /// let p = vec![SepSRgb8::new(255, 0, 255); 16]; // vec of magenta pix
     /// let mut r = RasterBuilder::new()          // convert to raster
     ///     .with_pixels(4, 4, p);
-    /// let clr = Rgb8::new(0x00, 0xFF, 0x00);    // green
+    /// let clr = SepSRgb8::new(0x00, 0xFF, 0x00);    // green
     /// r.set_region((2, 0, 1, 3), clr);          // make stripe
-    /// let p2 = Into::<Vec<Rgb8>>::into(r);      // convert back to vec
+    /// let p2 = Into::<Vec<SepSRgb8>>::into(r);      // convert back to vec
     /// ```
     pub fn with_pixels<B>(self, width: u32, height: u32, pixels: B) -> Raster<F>
     where
@@ -343,20 +343,20 @@ impl<F: Format> Raster<F> {
     /// ### Set entire raster to one color
     /// ```
     /// # use pix::*;
-    /// let mut r = RasterBuilder::<Rgb32>::new().with_clear(360, 240);
-    /// r.set_region(r.region(), Rgb32::new(0.5, 0.2, 0.8));
+    /// let mut r = RasterBuilder::<SepSRgb32>::new().with_clear(360, 240);
+    /// r.set_region(r.region(), SepSRgb32::new(0.5, 0.2, 0.8));
     /// ```
     /// ### Set rectangle to solid color
     /// ```
     /// # use pix::*;
-    /// let mut raster = RasterBuilder::<Rgb8>::new().with_clear(100, 100);
-    /// raster.set_region((20, 40, 25, 50), Rgb8::new(0xDD, 0x96, 0x70));
+    /// let mut raster = RasterBuilder::<SepSRgb8>::new().with_clear(100, 100);
+    /// raster.set_region((20, 40, 25, 50), SepSRgb8::new(0xDD, 0x96, 0x70));
     /// ```
     /// ### Copy part of one `Raster` to another, converting pixel format
     /// ```
     /// # use pix::*;
-    /// let mut rgb = RasterBuilder::<Rgb8>::new().with_clear(100, 100);
-    /// let mut gray = RasterBuilder::<Gray16>::new().with_clear(50, 50);
+    /// let mut rgb = RasterBuilder::<SepSRgb8>::new().with_clear(100, 100);
+    /// let mut gray = RasterBuilder::<SepSGray16>::new().with_clear(50, 50);
     /// // ... load image data
     /// let src = gray.region().intersection((20, 10, 25, 25));
     /// let dst = rgb.region().intersection((40, 40, 25, 25));
@@ -651,8 +651,8 @@ mod test {
     }
     #[test]
     fn rgb8() {
-        let mut r = RasterBuilder::<Rgb8>::new().with_clear(4, 4);
-        let rgb = Rgb8::new(0xCC, 0xAA, 0xBB);
+        let mut r = RasterBuilder::<SepSRgb8>::new().with_clear(4, 4);
+        let rgb = SepSRgb8::new(0xCC, 0xAA, 0xBB);
         r.set_region((1, 1, 2, 2), rgb);
         let v = vec![
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -665,10 +665,10 @@ mod test {
     }
     #[test]
     fn gray8() {
-        let mut r = RasterBuilder::<Gray8>::new().with_clear(4, 4);
-        r.set_region((0, 0, 1, 1), Gray8::from(0x23));
-        r.set_region((10, 10, 1, 1), Gray8::from(0x45));
-        r.set_region((2, 2, 10, 10), Gray8::from(0xBB));
+        let mut r = RasterBuilder::<SepSGray8>::new().with_clear(4, 4);
+        r.set_region((0, 0, 1, 1), SepSGray8::from(0x23));
+        r.set_region((10, 10, 1, 1), SepSGray8::from(0x45));
+        r.set_region((2, 2, 10, 10), SepSGray8::from(0xBB));
         let v = vec![
             0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xBB,
             0xBB, 0x00, 0x00, 0xBB, 0xBB,
@@ -682,8 +682,8 @@ mod test {
             0x00, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0x00, 0x00, 0xCC, 0xCC,
             0xDD, 0xEE, 0xFF, 0x00, 0x11,
         ];
-        let mut r = RasterBuilder::<Rgb8>::new().with_u8_buffer(3, 3, b);
-        let rgb = Rgb8::new(0x12, 0x34, 0x56);
+        let mut r = RasterBuilder::<SepSRgb8>::new().with_u8_buffer(3, 3, b);
+        let rgb = SepSRgb8::new(0x12, 0x34, 0x56);
         r.set_region((0, 1, 2, 1), rgb);
         let v = vec![
             0xAA, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x12, 0x34,
@@ -700,8 +700,8 @@ mod test {
             0xA00B, 0x8009,
         ];
         let mut r =
-            RasterBuilder::<GrayAlpha16>::new().with_u16_buffer(3, 3, b);
-        r.set_region((1, 0, 2, 2), GrayAlpha16::new(0x4444));
+            RasterBuilder::<SepSGrayAlpha16>::new().with_u16_buffer(3, 3, b);
+        r.set_region((1, 0, 2, 2), SepSGrayAlpha16::new(0x4444));
         let v = vec![
             0x01, 0x10, 0x05, 0x50, 0x44, 0x44, 0xFF, 0xFF, 0x44, 0x44, 0xFF,
             0xFF, 0x02, 0x20, 0x06, 0x60, 0x44, 0x44, 0xFF, 0xFF, 0x44, 0x44,
@@ -713,10 +713,10 @@ mod test {
     }
     #[test]
     fn gray_to_rgb() {
-        let mut r = RasterBuilder::<Gray8>::new().with_clear(3, 3);
-        r.set_region((2, 0, 4, 2), Gray8::new(0x45));
-        r.set_region((0, 2, 2, 10), Gray8::new(0xDA));
-        let r = RasterBuilder::<Rgb8>::new().with_raster(&r);
+        let mut r = RasterBuilder::<SepSGray8>::new().with_clear(3, 3);
+        r.set_region((2, 0, 4, 2), SepSGray8::new(0x45));
+        r.set_region((0, 2, 2, 10), SepSGray8::new(0xDA));
+        let r = RasterBuilder::<SepSRgb8>::new().with_raster(&r);
         let v = vec![
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x45, 0x45, 0x45, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x45, 0x45, 0x45, 0xDA, 0xDA, 0xDA, 0xDA,
@@ -726,18 +726,18 @@ mod test {
     }
     #[test]
     fn rgb_to_gray() {
-        let mut r = RasterBuilder::<Rgb16>::new().with_clear(3, 3);
-        r.set_region((1, 0, 4, 2), Rgb16::new(0x4321, 0x9085, 0x5543));
-        r.set_region((0, 1, 1, 10), Rgb16::new(0x5768, 0x4091, 0x5000));
-        let r = RasterBuilder::<Gray8>::new().with_raster(&r);
+        let mut r = RasterBuilder::<SepSRgb16>::new().with_clear(3, 3);
+        r.set_region((1, 0, 4, 2), SepSRgb16::new(0x4321, 0x9085, 0x5543));
+        r.set_region((0, 1, 1, 10), SepSRgb16::new(0x5768, 0x4091, 0x5000));
+        let r = RasterBuilder::<SepSGray8>::new().with_raster(&r);
         let v = vec![0x00, 0x90, 0x90, 0x57, 0x90, 0x90, 0x57, 0x00, 0x00];
         assert_eq!(r.as_u8_slice(), &v[..]);
     }
     #[test]
     fn gray_to_mask() {
-        let mut r = RasterBuilder::<GrayAlpha8>::new().with_clear(3, 3);
-        r.set_region((0, 1, 2, 8), GrayAlpha8::with_alpha(0x67, 0x94));
-        r.set_region((2, 0, 1, 10), GrayAlpha8::with_alpha(0xBA, 0xA2));
+        let mut r = RasterBuilder::<SepSGrayAlpha8>::new().with_clear(3, 3);
+        r.set_region((0, 1, 2, 8), SepSGrayAlpha8::with_alpha(0x67, 0x94));
+        r.set_region((2, 0, 1, 10), SepSGrayAlpha8::with_alpha(0xBA, 0xA2));
         let r = RasterBuilder::<Mask16>::new().with_raster(&r);
         let v = vec![
             0x00, 0x00, 0x00, 0x00, 0xA2, 0xA2, 0x94, 0x94, 0x94, 0x94, 0xA2,
@@ -750,7 +750,7 @@ mod test {
         let mut r = RasterBuilder::<Mask16>::new().with_clear(3, 3);
         r.set_region((0, 1, 3, 8), Mask16::new(0xABCD));
         r.set_region((2, 0, 1, 3), Mask16::new(0x9876));
-        let r = RasterBuilder::<GrayAlpha8>::new().with_raster(&r);
+        let r = RasterBuilder::<SepSGrayAlpha8>::new().with_raster(&r);
         let v = vec![
             0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x98, 0xFF, 0xAB, 0xFF, 0xAB, 0xFF,
             0x98, 0xFF, 0xAB, 0xFF, 0xAB, 0xFF, 0x98,
@@ -759,10 +759,10 @@ mod test {
     }
     #[test]
     fn copy_region_gray() {
-        let mut g0 = RasterBuilder::<Gray16>::new().with_clear(3, 3);
-        let mut g1 = RasterBuilder::<LinearGray16>::new().with_clear(3, 3);
-        g0.set_region((0, 2, 2, 5), Gray16::new(0x4455));
-        g0.set_region((2, 0, 3, 2), Gray8::new(0x33));
+        let mut g0 = RasterBuilder::<SepSGray16>::new().with_clear(3, 3);
+        let mut g1 = RasterBuilder::<SepLGray16>::new().with_clear(3, 3);
+        g0.set_region((0, 2, 2, 5), SepSGray16::new(0x4455));
+        g0.set_region((2, 0, 3, 2), SepSGray8::new(0x33));
         g1.set_region(g1.region(), g0.region_iter(g0.region()));
         let v = vec![
             0x00, 0x00, 0x00, 0x00, 0x7A, 0x08, 0x00, 0x00, 0x00, 0x00, 0x7A,
@@ -772,18 +772,18 @@ mod test {
     }
     #[test]
     fn from_rgb8() {
-        let r = RasterBuilder::<Rgb8>::new().with_clear(50, 50);
-        let _ = RasterBuilder::<Rgb16>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgb32>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgba8>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgba16>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgba32>::new().with_raster(&r);
-        let _ = RasterBuilder::<Gray8>::new().with_raster(&r);
-        let _ = RasterBuilder::<Gray16>::new().with_raster(&r);
-        let _ = RasterBuilder::<Gray32>::new().with_raster(&r);
-        let _ = RasterBuilder::<GrayAlpha8>::new().with_raster(&r);
-        let _ = RasterBuilder::<GrayAlpha16>::new().with_raster(&r);
-        let _ = RasterBuilder::<GrayAlpha32>::new().with_raster(&r);
+        let r = RasterBuilder::<SepSRgb8>::new().with_clear(50, 50);
+        let _ = RasterBuilder::<SepSRgb16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgb32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgba8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgba16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgba32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGray8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGray16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGray32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGrayAlpha8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGrayAlpha16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGrayAlpha32>::new().with_raster(&r);
         let _ = RasterBuilder::<Mask8>::new().with_raster(&r);
         let _ = RasterBuilder::<Mask16>::new().with_raster(&r);
         let _ = RasterBuilder::<Mask32>::new().with_raster(&r);
@@ -791,18 +791,18 @@ mod test {
     #[test]
     fn from_mask8() {
         let r = RasterBuilder::<Mask8>::new().with_clear(50, 50);
-        let _ = RasterBuilder::<Rgb8>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgb16>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgb32>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgba8>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgba16>::new().with_raster(&r);
-        let _ = RasterBuilder::<Rgba32>::new().with_raster(&r);
-        let _ = RasterBuilder::<Gray8>::new().with_raster(&r);
-        let _ = RasterBuilder::<Gray16>::new().with_raster(&r);
-        let _ = RasterBuilder::<Gray32>::new().with_raster(&r);
-        let _ = RasterBuilder::<GrayAlpha8>::new().with_raster(&r);
-        let _ = RasterBuilder::<GrayAlpha16>::new().with_raster(&r);
-        let _ = RasterBuilder::<GrayAlpha32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgb8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgb16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgb32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgba8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgba16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSRgba32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGray8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGray16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGray32>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGrayAlpha8>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGrayAlpha16>::new().with_raster(&r);
+        let _ = RasterBuilder::<SepSGrayAlpha32>::new().with_raster(&r);
         let _ = RasterBuilder::<Mask8>::new().with_raster(&r);
         let _ = RasterBuilder::<Mask16>::new().with_raster(&r);
         let _ = RasterBuilder::<Mask32>::new().with_raster(&r);

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -9,9 +9,8 @@ use std::marker::PhantomData;
 
 /// Builder for [Raster](struct.Raster.html) images.
 ///
-/// After creating a `RasterBuilder`, the [AlphaMode](enum.AlphaMode.html) and
-/// [GammaMode](enum.GammaMode.html) can be configured.  To finish building a
-/// `Raster`, use one of the *with_* methods:
+/// After creating a `RasterBuilder`, finish building a `Raster` using one of
+/// the *with_* methods:
 /// * [with_clear](struct.RasterBuilder.html#method.with_clear)
 /// * [with_color](struct.RasterBuilder.html#method.with_color)
 /// * [with_raster](struct.RasterBuilder.html#method.with_raster)

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -318,10 +318,10 @@ pub type LRgb<C, A, M> = Rgb<C, A, M, LinearGamma>;
 
 /// [SeparatedAlpha](struct.SeparatedAlpha.html) [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type SepRgb<C, A, M> = Rgb<C, A, M, SeparatedAlpha>;
+pub type SepRgb<C, A, G> = Rgb<C, A, SeparatedAlpha, G>;
 /// [AssociatedAlpha](struct.AssociatedAlpha.html) [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type AssocRgb<C, A, M> = Rgb<C, A, M, AssociatedAlpha>;
+pub type AssocRgb<C, A, G> = Rgb<C, A, AssociatedAlpha, G>;
 
 /// [SeparatedAlpha](struct.SeparatedAlpha.html)
 /// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,6 +1,7 @@
 // rgb.rs       RGB pixel format.
 //
 // Copyright (c) 2018-2020  Douglas P Lau
+// Copyright (c) 2019-2020  Jeron Aldaron Lau
 //
 use crate::{
     Alpha, AlphaMode, AlphaModeID, AssociatedAlpha, Ch16, Ch32, Ch8, Channel,

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -292,82 +292,146 @@ where
 
 /// [Opaque](struct.Opaque.html) 8-bit [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type Rgb8 = Rgb<Ch8, Opaque<Ch8>, SeparatedAlpha, SrgbGamma>;
-
+pub type Rgb8<M, G> = Rgb<Ch8, Opaque<Ch8>, M, G>;
 /// [Opaque](struct.Opaque.html) 16-bit [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type Rgb16 = Rgb<Ch16, Opaque<Ch16>, SeparatedAlpha, SrgbGamma>;
-
+pub type Rgb16<M, G> = Rgb<Ch16, Opaque<Ch16>, M, G>;
 /// [Opaque](struct.Opaque.html) 32-bit [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type Rgb32 = Rgb<Ch32, Opaque<Ch32>, SeparatedAlpha, SrgbGamma>;
-
-/// [Opaque](struct.Opaque.html) 8-bit [Rgb](struct.Rgb.html) pixel
-/// [Format](trait.Format.html).
-pub type LinearRgb8 = Rgb<Ch8, Opaque<Ch8>, SeparatedAlpha, LinearGamma>;
-
-/// [Opaque](struct.Opaque.html) 16-bit [Rgb](struct.Rgb.html) pixel
-/// [Format](trait.Format.html).
-pub type LinearRgb16 = Rgb<Ch16, Opaque<Ch16>, SeparatedAlpha, LinearGamma>;
-
-/// [Opaque](struct.Opaque.html) 32-bit [Rgb](struct.Rgb.html) pixel
-/// [Format](trait.Format.html).
-pub type LinearRgb32 = Rgb<Ch32, Opaque<Ch32>, SeparatedAlpha, LinearGamma>;
-
+pub type Rgb32<M, G> = Rgb<Ch32, Opaque<Ch32>, M, G>;
 /// [Translucent](struct.Translucent.html) 8-bit [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type Rgba8 = Rgb<Ch8, Translucent<Ch8>, SeparatedAlpha, SrgbGamma>;
-
+pub type Rgba8<M, G> = Rgb<Ch8, Translucent<Ch8>, M, G>;
 /// [Translucent](struct.Translucent.html) 16-bit [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type Rgba16 = Rgb<Ch16, Translucent<Ch16>, SeparatedAlpha, SrgbGamma>;
-
+pub type Rgba16<M, G> = Rgb<Ch16, Translucent<Ch16>, M, G>;
 /// [Translucent](struct.Translucent.html) 32-bit [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type Rgba32 = Rgb<Ch32, Translucent<Ch32>, SeparatedAlpha, SrgbGamma>;
+pub type Rgba32<M, G> = Rgb<Ch32, Translucent<Ch32>, M, G>;
 
-/// [Translucent](struct.Translucent.html) 8-bit [Rgb](struct.Rgb.html) pixel
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type LinearRgba8 = Rgb<Ch8, Translucent<Ch8>, SeparatedAlpha, LinearGamma>;
+pub type SRgb<C, A, M> = Rgb<C, A, M, SrgbGamma>;
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type LRgb<C, A, M> = Rgb<C, A, M, LinearGamma>;
 
-/// [Translucent](struct.Translucent.html) 16-bit [Rgb](struct.Rgb.html) pixel
+/// [SeparatedAlpha](struct.SeparatedAlpha.html) [Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type LinearRgba16 =
-    Rgb<Ch16, Translucent<Ch16>, SeparatedAlpha, LinearGamma>;
+pub type SepRgb<C, A, M> = Rgb<C, A, M, SeparatedAlpha>;
+/// [AssociatedAlpha](struct.AssociatedAlpha.html) [Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocRgb<C, A, M> = Rgb<C, A, M, AssociatedAlpha>;
 
-/// [Translucent](struct.Translucent.html) 32-bit [Rgb](struct.Rgb.html) pixel
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type LinearRgba32 =
-    Rgb<Ch32, Translucent<Ch32>, SeparatedAlpha, LinearGamma>;
+pub type SepSRgb<C, A> = SRgb<C, A, SeparatedAlpha>;
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgb<C, A> = LRgb<C, A, SeparatedAlpha>;
+/// [AssociatedAlpha](struct.AssociatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocSRgb<C, A> = SRgb<C, A, AssociatedAlpha>;
+/// [AssociatedAlpha](struct.AssociatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocLRgb<C, A> = LRgb<C, A, AssociatedAlpha>;
 
-/// [Translucent](struct.Translucent.html) 8-bit [Rgb](struct.Rgb.html) pixel
+/// [Opaque](struct.Opaque.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulRgba8 = Rgb<Ch8, Translucent<Ch8>, AssociatedAlpha, SrgbGamma>;
+pub type SepSRgb8 = SepSRgb<Ch8, Opaque<Ch8>>;
+/// [Opaque](struct.Opaque.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSRgb16 = SepSRgb<Ch16, Opaque<Ch16>>;
+/// [Opaque](struct.Opaque.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSRgb32 = SepSRgb<Ch32, Opaque<Ch32>>;
+/// [Opaque](struct.Opaque.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgb8 = SepLRgb<Ch8, Opaque<Ch8>>;
+/// [Opaque](struct.Opaque.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgb16 = SepLRgb<Ch16, Opaque<Ch16>>;
+/// [Opaque](struct.Opaque.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgb32 = SepLRgb<Ch32, Opaque<Ch32>>;
 
-/// [Translucent](struct.Translucent.html) 16-bit [Rgb](struct.Rgb.html) pixel
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulRgba16 =
-    Rgb<Ch16, Translucent<Ch16>, AssociatedAlpha, SrgbGamma>;
+pub type SepSRgba8 = SepSRgb<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSRgba16 = SepSRgb<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepSRgba32 = SepSRgb<Ch32, Translucent<Ch32>>;
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgba8 = SepLRgb<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgba16 = SepLRgb<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type SepLRgba32 = SepLRgb<Ch32, Translucent<Ch32>>;
 
-/// [Translucent](struct.Translucent.html) 32-bit [Rgb](struct.Rgb.html) pixel
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulRgba32 =
-    Rgb<Ch32, Translucent<Ch32>, AssociatedAlpha, SrgbGamma>;
-
-/// [Translucent](struct.Translucent.html) 8-bit [Rgb](struct.Rgb.html) pixel
+pub type AssocSRgba8 = AssocSRgb<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulLinearRgba8 =
-    Rgb<Ch8, Translucent<Ch8>, AssociatedAlpha, LinearGamma>;
-
-/// [Translucent](struct.Translucent.html) 16-bit [Rgb](struct.Rgb.html) pixel
+pub type AssocSRgba16 = AssocSRgb<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [S](struct.SrgbGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulLinearRgba16 =
-    Rgb<Ch16, Translucent<Ch16>, AssociatedAlpha, LinearGamma>;
-
-/// [Translucent](struct.Translucent.html) 32-bit [Rgb](struct.Rgb.html) pixel
+pub type AssocSRgba32 = AssocSRgb<Ch32, Translucent<Ch32>>;
+/// [Translucent](struct.Translucent.html) 8-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
 /// [Format](trait.Format.html).
-pub type PremulLinearRgba32 =
-    Rgb<Ch32, Translucent<Ch32>, AssociatedAlpha, LinearGamma>;
+pub type AssocLRgba8 = AssocLRgb<Ch8, Translucent<Ch8>>;
+/// [Translucent](struct.Translucent.html) 16-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocLRgba16 = AssocLRgb<Ch16, Translucent<Ch16>>;
+/// [Translucent](struct.Translucent.html) 32-bit
+/// [SeparatedAlpha](struct.SeparatedAlpha.html)
+/// [L](struct.LinearGamma.html)[Rgb](struct.Rgb.html) pixel
+/// [Format](trait.Format.html).
+pub type AssocLRgba32 = AssocLRgb<Ch32, Translucent<Ch32>>;
 
 #[cfg(test)]
 mod test {
@@ -375,34 +439,34 @@ mod test {
 
     #[test]
     fn check_sizes() {
-        assert_eq!(std::mem::size_of::<Rgb8>(), 3);
-        assert_eq!(std::mem::size_of::<Rgb16>(), 6);
-        assert_eq!(std::mem::size_of::<Rgb32>(), 12);
-        assert_eq!(std::mem::size_of::<Rgba8>(), 4);
-        assert_eq!(std::mem::size_of::<Rgba16>(), 8);
-        assert_eq!(std::mem::size_of::<Rgba32>(), 16);
+        assert_eq!(std::mem::size_of::<SepSRgb8>(), 3);
+        assert_eq!(std::mem::size_of::<SepSRgb16>(), 6);
+        assert_eq!(std::mem::size_of::<SepSRgb32>(), 12);
+        assert_eq!(std::mem::size_of::<SepSRgba8>(), 4);
+        assert_eq!(std::mem::size_of::<SepSRgba16>(), 8);
+        assert_eq!(std::mem::size_of::<SepSRgba32>(), 16);
     }
 
     #[test]
     fn check_mul() {
-        let a = Rgba8::with_alpha(0xFF, 0xFF, 0xFF, 0xFF);
-        let b = Rgba8::with_alpha(0x00, 0x00, 0x00, 0x00);
+        let a = SepSRgba8::with_alpha(0xFF, 0xFF, 0xFF, 0xFF);
+        let b = SepSRgba8::with_alpha(0x00, 0x00, 0x00, 0x00);
 
         assert_eq!(a * b, b);
 
-        let a = Rgba8::with_alpha(0xFF, 0xFF, 0xFF, 0xFF);
-        let b = Rgba8::with_alpha(0x80, 0x80, 0x80, 0x80);
+        let a = SepSRgba8::with_alpha(0xFF, 0xFF, 0xFF, 0xFF);
+        let b = SepSRgba8::with_alpha(0x80, 0x80, 0x80, 0x80);
 
         assert_eq!(a * b, b);
 
-        let a = Rgba8::with_alpha(0xFF, 0xF0, 0x00, 0x70);
-        let b = Rgba8::with_alpha(0x80, 0x00, 0x60, 0xFF);
+        let a = SepSRgba8::with_alpha(0xFF, 0xF0, 0x00, 0x70);
+        let b = SepSRgba8::with_alpha(0x80, 0x00, 0x60, 0xFF);
 
-        assert_eq!(a * b, Rgba8::with_alpha(0x80, 0x00, 0x00, 0x70));
+        assert_eq!(a * b, SepSRgba8::with_alpha(0x80, 0x00, 0x00, 0x70));
 
-        let a = Rgba8::with_alpha(0xFF, 0x00, 0x80, 0xFF);
-        let b = Rgba8::with_alpha(0xFF, 0xFF, 0xFF, 0x10);
+        let a = SepSRgba8::with_alpha(0xFF, 0x00, 0x80, 0xFF);
+        let b = SepSRgba8::with_alpha(0xFF, 0xFF, 0xFF, 0x10);
 
-        assert_eq!(a * b, Rgba8::with_alpha(0xFF, 0x00, 0x80, 0x10));
+        assert_eq!(a * b, SepSRgba8::with_alpha(0xFF, 0x00, 0x80, 0x10));
     }
 }


### PR DESCRIPTION
These names should be more memorable and shorter than the ones from my original PR.  This also adds a `Format::convert()` method which is the same as the one that was used internally in `Raster`.  This PR also adds documentation for naming conventions, and updates old documentation so that it is accurate.